### PR TITLE
fix: make meta optional as documented

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -23,7 +23,7 @@ export interface FluxStandardAction<Payload, Meta = undefined> {
    * The optional `meta` property MAY be any type of value.
    * It is intended for any extra information that is not part of the payload.
    */
-  meta: Meta;
+  meta?: Meta;
 }
 
 export interface ErrorFluxStandardAction<CustomError extends Error, Meta = undefined> extends FluxStandardAction<CustomError, Meta> {


### PR DESCRIPTION
I'm providing with pull request a little example how it can be used with action creators. Because in current implementation action creator must return 'meta' explicit.

[Link to Typescript playground](http://www.typescriptlang.org/play/index.html#src=interface%20FSA%3CP%2C%20M%20%3D%20undefined%3E%20%7B%0D%0A%20%20%20%20type%3A%20string%2C%0D%0A%20%20%20%20payload%3A%20P%0D%0A%20%20%20%20meta%3F%3A%20M%0D%0A%7D%0D%0A%0D%0Aconst%20action1%3A%20FSA%3Cnumber%3E%20%3D%20%7B%20type%3A%20'ACTION_1'%2C%20payload%3A%201%20%7D%3B%0D%0A%0D%0A%2F%2F%20meta%20will%20undefined%20anyways%20when%20not%20provided%0D%0Aalert('meta%20of%20action1%20is%3A%20'%20%2B%20action1.meta)%0D%0A%0D%0Aconst%20action2%3A%20FSA%3Cnumber%2C%20%7B%20test%3A%20boolean%20%7D%3E%20%3D%20%7B%20type%3A%20'ACTION_2'%2C%20payload%3A%202%2C%20meta%3A%20%7Btest%3A%20true%7D%20%7D%3B%0D%0A%0D%0Aconst%20action3%3A%20FSA%3Cnumber%3E%20%3D%20%7B%20type%3A%20'ACTION_3'%2C%20payload%3A%203%2C%20meta%3A%20undefined%20%7D%3B%0D%0A%0D%0Aconst%20actionCreator%20%3D%20(payload)%3A%20FSA%3Cnumber%3E%20%3D%3E%20(%7B%0D%0A%20%20%20%20type%3A%20'ACTION_4'%2C%0D%0A%20%20%20%20payload%3A%20payload%0D%0A%7D)%3B%0D%0A%0D%0Aconst%20action4%20%3D%20actionCreator(4)%3B%0D%0A%0D%0Aalert(JSON.stringify(action4))%3B)