### PR TITLE
Add TypeScript definitions to enforce that `payload` and/or `meta` properties are defined.

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "lines": 100,
         "statements": 100
       }
-    }
+    },
+    "testURL": "http://localhost"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,12 @@
-export interface FluxStandardAction<Payload, Meta = undefined> {
+interface FluxStandardActionRequiredKeys {
   /**
    * The `type` of an action identifies to the consumer the nature of the action that has occurred.
    * Two actions with the same `type` MUST be strictly equivalent (using `===`)
    */
   type: string;
+}
+
+interface FluxStandardActionOptionalKeys<Payload, Meta> {
   /**
    * The optional `payload` property MAY be any type of value.
    * It represents the payload of the action.
@@ -11,25 +14,85 @@ export interface FluxStandardAction<Payload, Meta = undefined> {
    * By convention, if `error` is `true`, the `payload` SHOULD be an error object.
    * This is akin to rejecting a promise with an error object.
    */
-  payload?: Payload;
+  payload: Payload;
   /**
    * The optional `error` property MAY be set to true if the action represents an error.
    * An action whose `error` is true is analogous to a rejected Promise.
    * By convention, the `payload` SHOULD be an error object.
    * If `error` has any other value besides `true`, including `undefined`, the action MUST NOT be interpreted as an error.
    */
-  error?: boolean;
+  error: boolean;
   /**
    * The optional `meta` property MAY be any type of value.
    * It is intended for any extra information that is not part of the payload.
    */
-  meta?: Meta;
+  meta: Meta;
 }
 
+/**
+ * Flux standard action. All properties except `type` are optional.
+ */
+export type FluxStandardAction<
+  Payload,
+  Meta = undefined
+> = FluxStandardActionRequiredKeys &
+  Partial<FluxStandardActionOptionalKeys<Payload, Meta>>;
+
+/**
+ * Enforces the `payload` property on an FSA cannot be optional.
+ */
+export type FluxStandardActionWithPayload<
+  Payload
+> = FluxStandardActionRequiredKeys &
+  Pick<FluxStandardActionOptionalKeys<Payload, undefined>, 'payload'>;
+
+/**
+ * Enforces the `meta` property on an FSA cannot be optional.
+ */
+export type FluxStandardActionWithMeta<Meta> = FluxStandardActionRequiredKeys &
+  Pick<FluxStandardActionOptionalKeys<undefined, Meta>, 'meta'>;
+
+/**
+ * Enforces the `payload` and `meta` properties on an FSA cannot be optional.
+ */
+export type FluxStandardActionWithPayloadAndMeta<
+  Payload,
+  Meta
+> = FluxStandardActionRequiredKeys &
+  Pick<FluxStandardActionOptionalKeys<Payload, Meta>, 'payload' | 'meta'>;
+
+/**
+ * A FluxStandardAction where the optional `payload` is enforced to inherit from Error.
+ * The `error` property must be true.
+ */
 export interface ErrorFluxStandardAction<
   CustomError extends Error,
   Meta = undefined
 > extends FluxStandardAction<CustomError, Meta> {
+  error: true;
+}
+
+/**
+ * Enforces the `payload` property on an error FSA cannot be null.
+ */
+export interface ErrorFluxStandardActionWithPayload<Payload extends Error>
+  extends FluxStandardActionWithPayload<Payload> {
+  error: true;
+}
+
+/**
+ * Enforces the `meta` property on an error FSA cannot be null.
+ */
+export interface ErrorFluxStandardActionWithMeta<Meta>
+  extends FluxStandardActionWithMeta<Meta> {
+  error: true;
+}
+
+/**
+ * Enforces the `payload` and `meta` properties on an error FSA cannot be null.
+ */
+export interface ErrorFluxStandardActionWithPayloadAndMeta<Payload, Meta>
+  extends FluxStandardActionWithPayloadAndMeta<Payload, Meta> {
   error: true;
 }
 
@@ -39,12 +102,50 @@ export interface ErrorFluxStandardAction<
 export type FSA<Payload, Meta = undefined> = FluxStandardAction<Payload, Meta>;
 
 /**
+ * Alias for FluxStandardActionWithPayload.
+ */
+export type FSAWithPayload<Payload> = FluxStandardActionWithPayload<Payload>;
+
+/**
+ * Alias for FluxStandardActionWithMeta.
+ */
+export type FSAWithMeta<Meta> = FluxStandardActionWithMeta<Meta>;
+
+/**
+ * Alias for FluxStandardActionWithPayloadAndMeta.
+ */
+export type FSAWithPayloadAndMeta<
+  Payload,
+  Meta
+> = FluxStandardActionWithPayloadAndMeta<Payload, Meta>;
+
+/**
  * Alias for ErrorFluxStandardAction.
  */
 export type ErrorFSA<
   CustomError extends Error,
   Meta = undefined
 > = ErrorFluxStandardAction<CustomError, Meta>;
+
+/**
+ * Alias for ErrorFluxStandardActionWithPayload.
+ */
+export type ErrorFSAWithPayload<
+  Payload extends Error
+> = ErrorFluxStandardActionWithPayload<Payload>;
+
+/**
+ * Alias for ErrorFluxStandardActionWithMeta.
+ */
+export type ErrorFSAWithMeta<Meta> = ErrorFluxStandardActionWithMeta<Meta>;
+
+/**
+ * Alias for ErrorFluxStandardActionWithPayloadAndMeta.
+ */
+export type ErrorFSAWithPayloadAndMeta<
+  Payload extends Error,
+  Meta
+> = ErrorFluxStandardActionWithPayloadAndMeta<Payload, Meta>;
 
 /**
  * Returns `true` if `action` is FSA compliant.


### PR DESCRIPTION
The issue I am having with the type definitions in this package are that the `payload` and `meta` properties on actions are marked optional.

When I define my own actions and extend the types using this package -- I know that some of my actions will and must always have a `payload` or `meta` property set.

With my TypeScipt compiler using the `--strictNullChecks` errors will be thrown when you try to access the `payload` or `meta` values as they could be undefined given the current definition of an FSA.

The work around would be to always do an `if` check to see if the properties are defined.

This is not very nice in your code.

I have proposed new definitions where you can specify and an FSA has a `payload` and/or `meta` property.

This has been documented in issue #109 .

This also fixes a small bug with the newer minor versions of Jest as documented in the commit message for that fix.