### PR TITLE
Add optional generic constraint for FSA type property

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  transform: {
+    '^.+\\.js$': 'babel-jest',
+    '^.+\\.tsx?$': 'ts-jest'
+  },
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']
+};

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "Andrew Clark <acdlite@me.com>",
   "license": "MIT",
   "devDependencies": {
+    "@types/jest": "^23.3.9",
     "babel-cli": "^6.26.0",
     "babel-plugin-lodash": "^3.3.2",
     "babel-preset-env": "^1.6.1",
@@ -43,7 +44,8 @@
     "prettier": "^1.12.1",
     "pretty-quick": "^1.4.1",
     "rimraf": "^2.6.1",
-    "typescript": "^2.8.3",
+    "ts-jest": "^23.10.4",
+    "typescript": "^3.1.6",
     "typescript-eslint-parser": "^15.0.0",
     "xo": "^0.20.3"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,7 +31,7 @@ export interface FluxStandardAction<
 }
 
 export interface ErrorFluxStandardAction<
-  CustomError extends Error,
+  CustomError extends Error = Error,
   Meta = undefined,
   Type extends string = string
 > extends FluxStandardAction<CustomError, Meta, Type> {
@@ -42,7 +42,7 @@ export interface ErrorFluxStandardAction<
  * Alias for FluxStandardAction.
  */
 export type FSA<
-  Payload,
+  Payload = undefined,
   Meta = undefined,
   Type extends string = string
 > = FluxStandardAction<Payload, Meta, Type>;
@@ -51,7 +51,7 @@ export type FSA<
  * Alias for ErrorFluxStandardAction.
  */
 export type ErrorFSA<
-  CustomError extends Error,
+  CustomError extends Error = Error,
   Meta = undefined,
   Type extends string = string
 > = ErrorFluxStandardAction<CustomError, Meta, Type>;
@@ -59,15 +59,17 @@ export type ErrorFSA<
 /**
  * Returns `true` if `action` is FSA compliant.
  */
-export function isFSA<Payload, Meta = undefined, Type extends string = string>(
-  action: any
-): action is FluxStandardAction<Payload, Meta, Type>;
+export function isFSA<
+  Payload = undefined,
+  Meta = undefined,
+  Type extends string = string
+>(action: any): action is FluxStandardAction<Payload, Meta, Type>;
 
 /**
  * Returns `true` if `action` is FSA compliant error.
  */
 export function isError<
-  CustomError extends Error,
+  CustomError extends Error = Error,
   Meta = undefined,
   Type extends string = string
 >(action: any): action is ErrorFluxStandardAction<CustomError, Meta, Type>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,13 @@
-export interface FluxStandardAction<Payload, Meta = undefined> {
+export interface FluxStandardAction<
+  Payload = undefined,
+  Meta = undefined,
+  Type extends string = string
+> {
   /**
    * The `type` of an action identifies to the consumer the nature of the action that has occurred.
    * Two actions with the same `type` MUST be strictly equivalent (using `===`)
    */
-  type: string;
+  type: Type;
   /**
    * The optional `payload` property MAY be any type of value.
    * It represents the payload of the action.
@@ -28,34 +32,42 @@ export interface FluxStandardAction<Payload, Meta = undefined> {
 
 export interface ErrorFluxStandardAction<
   CustomError extends Error,
-  Meta = undefined
-> extends FluxStandardAction<CustomError, Meta> {
+  Meta = undefined,
+  Type extends string = string
+> extends FluxStandardAction<CustomError, Meta, Type> {
   error: true;
 }
 
 /**
  * Alias for FluxStandardAction.
  */
-export type FSA<Payload, Meta = undefined> = FluxStandardAction<Payload, Meta>;
+export type FSA<
+  Payload,
+  Meta = undefined,
+  Type extends string = string
+> = FluxStandardAction<Payload, Meta, Type>;
 
 /**
  * Alias for ErrorFluxStandardAction.
  */
 export type ErrorFSA<
   CustomError extends Error,
-  Meta = undefined
-> = ErrorFluxStandardAction<CustomError, Meta>;
+  Meta = undefined,
+  Type extends string = string
+> = ErrorFluxStandardAction<CustomError, Meta, Type>;
 
 /**
  * Returns `true` if `action` is FSA compliant.
  */
-export function isFSA<Payload, Meta = undefined>(
+export function isFSA<Payload, Meta = undefined, Type extends string = string>(
   action: any
-): action is FluxStandardAction<Payload, Meta>;
+): action is FluxStandardAction<Payload, Meta, Type>;
 
 /**
  * Returns `true` if `action` is FSA compliant error.
  */
-export function isError<CustomError extends Error, Meta = undefined>(
-  action: any
-): action is ErrorFluxStandardAction<CustomError, Meta>;
+export function isError<
+  CustomError extends Error,
+  Meta = undefined,
+  Type extends string = string
+>(action: any): action is ErrorFluxStandardAction<CustomError, Meta, Type>;

--- a/test/typeFSA.test.ts
+++ b/test/typeFSA.test.ts
@@ -1,0 +1,18 @@
+import { FSA } from '../src';
+
+const ACTION_TYPE_1 = 'ACTION_TYPE_1';
+type ACTION_TYPE_1 = typeof ACTION_TYPE_1;
+type FSA_ACTION_TYPE_1 = FSA<undefined, undefined, ACTION_TYPE_1>;
+
+const assertNever = (x: never): never => {
+  throw new Error(`Unexpected value: ${x}.`);
+};
+
+describe('FluxStandardAction<Payload, Meta, Type>', () => {
+  it('enables TypeScript action type enforcement', () => {
+    const fsa_strict: FSA_ACTION_TYPE_1 = { type: ACTION_TYPE_1 };
+    if (fsa_strict.type !== ACTION_TYPE_1) {
+      throw assertNever(fsa_strict.type);
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,5 @@
     "strictNullChecks": true,
     "target": "es5"
   },
-  "files": [
-    "test/typings.test.ts"
-  ]
+  "files": ["src/index.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,11 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@types/jest@^23.3.9":
+  version "23.3.9"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.9.tgz#c16b55186ee73ae65e001fbee69d392c51337ad1"
+  integrity sha512-wNMwXSUcwyYajtbayfPp55tSayuDVU6PfY5gzvRSj80UvxdXEJOVPnUVajaOp7NgXLm+1e2ZDLULmpsU9vDvQw==
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -887,6 +892,13 @@ browserslist@^2.1.2:
     caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
 
+bs-logger@0.x:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.5.tgz#1d82f0cf88864e1341cd9262237f8d0748a49b22"
+  integrity sha512-uFLE0LFMxrH8Z5Hd9QgivvRbrl/NFkOTHzGhlqQxsnmx5JBLrp4bc249afLL+GccyY/8hkcGi2LpVaOzaEY0nQ==
+  dependencies:
+    fast-json-stable-stringify "^2.0.0"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -896,6 +908,11 @@ bser@^2.0.0:
 buf-compare@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buf-compare/-/buf-compare-1.0.1.tgz#fef28da8b8113a0a0db4430b0b6467b69730b34a"
+
+buffer-from@1.x:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 buffer-from@^1.0.0:
   version "1.0.0"
@@ -1803,7 +1820,7 @@ fast-glob@^2.0.2:
     merge2 "^1.2.1"
     micromatch "^3.1.10"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
@@ -3022,6 +3039,13 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
+json5@2.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
+  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+  dependencies:
+    minimist "^1.2.0"
+
 json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
@@ -3213,6 +3237,11 @@ make-dir@^1.0.0:
   dependencies:
     pify "^3.0.0"
 
+make-error@1.x:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
+  integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -3366,7 +3395,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -4244,6 +4273,11 @@ semver-diff@^2.0.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
+semver@^5.5:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -4644,6 +4678,20 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+ts-jest@^23.10.4:
+  version "23.10.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.10.4.tgz#a7a953f55c9165bcaa90ff91014a178e87fe0df8"
+  integrity sha512-oV/wBwGUS7olSk/9yWMiSIJWbz5xO4zhftnY3gwv6s4SMg6WHF1m8XZNBvQOKQRiTAexZ9754Z13dxBq3Zgssw==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    json5 "2.x"
+    make-error "1.x"
+    mkdirp "0.x"
+    semver "^5.5"
+    yargs-parser "10.x"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -4671,9 +4719,10 @@ typescript-eslint-parser@^15.0.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@^2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
 uglify-js@^2.6:
   version "2.8.29"
@@ -4981,6 +5030,13 @@ yallist@^2.1.2:
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
+
+yargs-parser@10.x:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^8.1.0:
   version "8.1.0"


### PR DESCRIPTION
* Make `Payload` type constaint optional (default to `undefined`) to allow shorthand FSA declarations for Actions without payloads.
* Introduce new option `Type` type constraint (defaults to `string`) to allow shorthand FSA declarations for strong typing of the `type` property.

In TypeScript it is common to define actions with the `type` property declared as `type: typeof ACTION_TYPE`.

Thus, we might as well add an additional optional type constraint on the `FSA` type to express this.

For a Counter application example this makes it possible to change the following code:
``` ts
import { FSA } from 'flux-standard-action';

const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
type INCREMENT_COUNTER = typeof INCREMENT_COUNTER;
interface IncrementCounterAction extends FSA {
  type: INCREMENT_COUNTER;
}
```

to this:
``` ts
import { FSA } from 'flux-standard-action';

const INCREMENT_COUNTER = 'INCREMENT_COUNTER';
type IncrementCounterAction = FSA<undefined, undefined, typeof INCREMENT_COUNTER>;
```

removing the need to re-declare the `type` property. The need to explicitly define the `Meta` type as `undefined` is unfortunate, but cannot be avoided if backwards compatability is to be maintained.

The type is optional (defaults to `string`) and is added as a 3<sup>rd</sup> constraint and thus maintains backwards compatability.